### PR TITLE
Include UltraEdit backup files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -203,3 +203,6 @@ FakesAssemblies/
 
 # Visual Studio 6 workspace options file
 *.opt
+
+# UltraEdit backup files
+*.bak


### PR DESCRIPTION
UltraEdit is a text editor that I use in place of Notepad. It will create backups of files before saving the changes to disk. The default extension is .BAK.

While this modification was made for UltraEdit, other text editors also perform automatic backups.